### PR TITLE
Fixed points calculation in analytics/detail/summary pages.

### DIFF
--- a/src/context/KiinteistoProvider.tsx
+++ b/src/context/KiinteistoProvider.tsx
@@ -134,7 +134,22 @@ export function KiinteistoProvider({
   }
 
   function update(updated: Kiinteisto) {
-    const newList = kiinteistot.map((k) => (k.id === updated.id ? updated : k));
+    const painotetutPisteet = calPainotutPisteet(updated);
+    const oma_salkku = evalSalkku({
+      ...updated,
+      painotetutPisteet,
+    });
+
+    const normalized: Kiinteisto = {
+      ...updated,
+      painotetutPisteet,
+      oma_salkku,
+    };
+
+    const newList = kiinteistot.map((k) =>
+      k.id === updated.id ? normalized : k
+    );
+
     setKiinteistot(newList);
     persist(newList);
   }
@@ -147,21 +162,25 @@ export function KiinteistoProvider({
 
   function normalizeKiinteisto(raw: any): Kiinteisto | null {
     try {
-      return {
+      // 1. Perusnormalisointi (EI johdettuja arvoja)
+      const base: Kiinteisto = {
         id: Number(raw.id),
         nimi: String(raw.nimi ?? ""),
         osoite: String(raw.osoite ?? ""),
+        kayttotarkoitus: String(raw.kayttotarkoitus ?? ""),
         pinta_ala: Number(raw.pinta_ala ?? 0),
         rakennusvuosi: Number(raw.rakennusvuosi ?? 0),
         suojelukohde: Boolean(raw.suojelukohde),
-        oma_salkku: raw.oma_salkku ?? "D",
-        oma_perusteet: String(raw.oma_perusteet ?? ""),
-        toimenpiteet: Array.isArray(raw.toimenpiteet) ? raw.toimenpiteet : [],
 
         pisteet:
           raw.pisteet && typeof raw.pisteet === "object"
             ? raw.pisteet
             : {},
+
+        oma_perusteet: String(raw.oma_perusteet ?? ""),
+        toimenpiteet: Array.isArray(raw.toimenpiteet)
+          ? raw.toimenpiteet
+          : [],
 
         yllapitokulut:
           raw.yllapitokulut && typeof raw.yllapitokulut === "object"
@@ -173,12 +192,30 @@ export function KiinteistoProvider({
             ? raw.vuokrakulut
             : {},
 
-        painotetutPisteet: Number(raw.painotetutPisteet ?? 0),
+        // asetetaan väliaikaisesti, korvataan heti
+        painotetutPisteet: 0,
+        oma_salkku: "D",
       };
-    } catch {
+
+      // 2. Johdetut arvot (AINOA TOTUUS)
+      const painotetutPisteet = calPainotutPisteet(base);
+      const oma_salkku = evalSalkku({
+        ...base,
+        painotetutPisteet,
+      });
+
+      // 3. Lopullinen, validi Kiinteisto
+      return {
+        ...base,
+        painotetutPisteet,
+        oma_salkku,
+      };
+    } catch (error) {
+      console.error("Failed to normalize Kiinteisto:", error);
       return null;
     }
   }
+
 
   useEffect(() => {
     async function initData() {

--- a/src/pages/AnalyticsView.tsx
+++ b/src/pages/AnalyticsView.tsx
@@ -223,10 +223,10 @@ export default function AnalyticsView() {
                                 style={{ cursor: "pointer" }}
                             >
                                 <td style={tdStyle}>{k.nimi}</td>
-                                <td style={{ ...tdStyle, ...badgeStyle(k.oma_salkku as "A" | "B" | "C" | "D") }}>
+                                <td style={{ ...tdStyle, ...badgeStyle(k.oma_salkku) }}>
                                     {k.oma_salkku}
                                 </td>
-                                <td style={tdStyle}>{laskePisteet(k)}</td>
+                                <td style={tdStyle}>{k.painotetutPisteet.toFixed(0)}</td>
                                 <td style={tdStyle}>{k.pinta_ala}</td>
                                 <td style={tdStyle}>{laskeTasearvo(k, year)}</td>
                                 <td style={tdStyle}>{laskeYllapito(k, year)}</td>

--- a/src/pages/SummaryView.tsx
+++ b/src/pages/SummaryView.tsx
@@ -1,30 +1,30 @@
-import { NavLink } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
 import { useKiinteistot } from "../context/useKiinteistot";
 
-import DonutChart from "../components/charts/DonutChart";
 import PointsBarChart from "../components/charts/Barchart";
+import DonutChart from "../components/charts/DonutChart";
 import formatNumberShort from "../utils/formatUtils";
 
 import {
-  boxesContainer,
   box,
+  boxesContainer,
   boxName,
-  boxValue,
   boxTitle,
-  secondRowContainer,
-  realEstatesContainer,
-  realEstateRow,
-  realEstateRowTitles,
-  realEstateTitle,
-  realEstateTitle2,
+  boxValue,
+  chartContainer,
   estateName,
   estateNumber,
   portfolioCell,
-  chartContainer,
-  portfolioRowStyle,
   portfolioItemHover,
+  portfolioRowStyle,
+  realEstateRow,
+  realEstateRowTitles,
+  realEstatesContainer,
+  realEstateTitle,
+  realEstateTitle2,
   salkkuBadge,
+  secondRowContainer,
   yearFilterButton,
   yearFilterContainer,
 } from "./SummaryView.styles";
@@ -155,7 +155,7 @@ export default function HomePage() {
             <DonutChart />
           </div>
           <div style={chartContainer}>
-            <PointsBarChart/>
+            <PointsBarChart />
           </div>
         </div>
       </div>

--- a/src/pages/detailView.tsx
+++ b/src/pages/detailView.tsx
@@ -2,20 +2,20 @@ import Chart from "chart.js/auto";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { ArviointiParametrit } from "../context/arviointiParametrit";
 import { useKiinteistot } from "../context/useKiinteistot";
 import {
-  flexContainer,
+  backButton,
+  badgeStyle,
   cardStyle,
+  chartCanvas,
+  chartCard,
+  flexContainer,
   sectionTitle,
   tableStyle,
   tdStyle,
-  backButton,
-  badgeStyle,
-  chartCanvas,
-  chartCard,
 } from "../styles";
 import type { Kiinteisto } from "../types";
-import { ArviointiParametrit } from "../context/arviointiParametrit";
 
 type Tab = "perustiedot" | "kuntoarviointi" | "toimenpiteet" | "talous";
 
@@ -122,25 +122,25 @@ export default function DetailView() {
   return (
     <div style={flexContainer}>
       {/* ================= HEADER ================= */}
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        marginBottom: "16px",
-      }}
-    >
-      <button style={backButton} onClick={() => navigate(-1)}>
-        ← Takaisin
-      </button>
-
-      <button
-        style={backButton}
-        onClick={() => navigate(`/add?id=${item.id}`)}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "16px",
+        }}
       >
-        ✎ Muokkaa
-      </button>
-    </div>
+        <button style={backButton} onClick={() => navigate(-1)}>
+          ← Takaisin
+        </button>
+
+        <button
+          style={backButton}
+          onClick={() => navigate(`/add?id=${item.id}`)}
+        >
+          ✎ Muokkaa
+        </button>
+      </div>
 
       <h1>{item.nimi}</h1>
       <p>{item.osoite}</p>
@@ -180,14 +180,14 @@ export default function DetailView() {
           <DetailCard
             title="Kiinteistön tiedot"
             rows={[
-              ["Pinta-ala", `${item.pinta_ala} m²`],
-              ["Rakennusvuosi", item.rakennusvuosi],
-              ["Käyttötarkoitus", item.kayttotarkoitus],
+              ["Pinta-ala", item.pinta_ala ?? "Ei tietoa"],
+              ["Rakennusvuosi", item.rakennusvuosi ?? "Ei tietoa"],
+              ["Käyttötarkoitus", item.kayttotarkoitus ?? "Ei tietoa"],
               ["Suojelukohde", item.suojelukohde ? "Kyllä" : "Ei"],
               ["Tasearvo", item.vuokrakulut[latestYear]?.tasearvo ?? "Ei saatavilla"],
-              ["Ylläpitokulut / v", yllapitoYhteensa],
-              ["Vuokratulot / v", vuokratulot],
-              ["Käyttöaste", `${kayttoaste} %`],
+              ["Ylläpitokulut / v", yllapitoYhteensa ?? "Ei saatavilla"],
+              ["Vuokratulot / v", vuokratulot ?? "Ei saatavilla"],
+              ["Käyttöaste (%)", kayttoaste ?? "Ei tietoa"],
             ]}
           />
 
@@ -202,7 +202,7 @@ export default function DetailView() {
               ],
               [
                 "Pisteet",
-                arviointiYhteensa.toFixed(1),
+                item.painotetutPisteet.toFixed(1),
               ],
               ["A > 225  •  B > 175  •  C > 125  •  D < 125", ""],
               [

--- a/src/utils/analyticsUtils.ts
+++ b/src/utils/analyticsUtils.ts
@@ -55,3 +55,12 @@ export function laskeKayttoaste(k: Kiinteisto, year: number): number {
         return 0;
     }
 }
+
+export function getPainotetutPisteet(k: Kiinteisto): number {
+    try {
+        return k.painotetutPisteet ?? 0;
+    } catch (error) {
+        console.error(`Error getting weighted points for ${k.nimi}:`, error);
+        return 0;
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where most properties were incorrectly classified as D‑class, even when the evaluation points indicated a higher category (A–C).
The root cause was an inconsistency between weighted point calculation, portfolio (salkku) evaluation, and how existing data was loaded and updated.
This PR unifies the domain logic and ensures portfolio classification is always derived from the correct weighted score.