### PR TITLE
85 kulut näytetään joko kuukausina tai vuosina

### DIFF
--- a/src/components/VuokrakulutModal.tsx
+++ b/src/components/VuokrakulutModal.tsx
@@ -15,7 +15,7 @@ function emptyVuokra(): VuokraKulut {
   return {
     tasearvo: 0,
     vuokrausaste_m2: 0,
-    neliövuokra: 0,
+    kokonaisvuokra: 0,
     sahkonkulutus: 0,
     lammitysenergia: 0,
     vedenkulutus: 0,
@@ -45,7 +45,9 @@ export default function VuokrakulutModal({
   }
 
   // Derived — not stored
-  const kokonaisvuokra = Math.round(form.vuokrattu * form.neliövuokra * 12);
+  const neliövuokra = form.vuokrattavissa > 0
+    ? form.kokonaisvuokra / form.vuokrattavissa
+    : 0;
   const kayttoaste = form.vuokrattavissa > 0
     ? Math.round((form.vuokrattu / form.vuokrattavissa) * 100)
     : 0;
@@ -122,9 +124,9 @@ export default function VuokrakulutModal({
               onChange={(e) => update("vuokrattavissa", Number(e.target.value))} style={inputStyle} />
           </div>
           <div>
-            <p style={labelStyle}>Neliövuokra (€/m²)</p>
-            <input type="number" value={form.neliövuokra || ""} placeholder="0"
-              onChange={(e) => update("neliövuokra", Number(e.target.value))} style={inputStyle} />
+            <p style={labelStyle}>Kokonaisvuokra / vuosi (€)</p>
+            <input type="number" value={form.kokonaisvuokra || ""} placeholder="0"
+              onChange={(e) => update("kokonaisvuokra", Number(e.target.value))} style={inputStyle} />
           </div>
           <div>
             <p style={labelStyle}>Vuokrausaste m² (legacy)</p>
@@ -143,8 +145,8 @@ export default function VuokrakulutModal({
           display: "flex",
           justifyContent: "space-between",
         }}>
-          <span>Kokonaisvuokra / v</span>
-          <strong>{kokonaisvuokra.toLocaleString("fi-FI")} €</strong>
+          <span>Neliövuokra</span>
+          <strong>{neliövuokra.toFixed(2)} €/m²</strong>
           <span style={{ marginLeft: 16 }}>Käyttöaste</span>
           <strong>{kayttoaste} %</strong>
         </div>

--- a/src/components/YllapitokulutModal.tsx
+++ b/src/components/YllapitokulutModal.tsx
@@ -12,12 +12,12 @@ interface Props {
 }
 
 const FIXED_FIELDS: { key: keyof Omit<YllapitoKulut, "muut" | "muutKulut">; label: string }[] = [
-  { key: "sahko",    label: "Sähkö" },
+  { key: "sahko", label: "Sähkö" },
   { key: "lammitys", label: "Lämmitys" },
-  { key: "vesi",     label: "Vesi" },
-  { key: "huolto",   label: "Huolto" },
-  { key: "vero",     label: "Kiinteistövero" },
-  { key: "laina",    label: "Laina" },
+  { key: "vesi", label: "Vesi" },
+  { key: "huolto", label: "Huolto" },
+  { key: "vero", label: "Kiinteistövero" },
+  { key: "laina", label: "Laina" },
 ];
 
 function emptyYllapito(): YllapitoKulut {

--- a/src/components/tabs/PerustiedotTab.tsx
+++ b/src/components/tabs/PerustiedotTab.tsx
@@ -9,44 +9,50 @@ interface Props {
 }
 
 export default function PerustiedotTab({ item, latestYear }: Props) {
-  const { yllapitoYhteensa, vuokratulot, kayttoaste } = computeFinancials(
-    item,
-    latestYear,
-  );
+  try {
+    const { yllapitoYhteensa, vuokratulot, kayttoaste } = computeFinancials(
+      item,
+      latestYear,
+    );
 
-  return (
-    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}>
-      <DetailCard
-        title="Kiinteistön tiedot"
-        rows={[
-          ["Pinta-ala", item.pinta_ala ?? "Ei tietoa"],
-          ["Rakennusvuosi", item.rakennusvuosi ?? "Ei tietoa"],
-          ["Käyttötarkoitus", item.kayttotarkoitus ?? "Ei tietoa"],
-          ["Suojelukohde", item.suojelukohde ? "Kyllä" : "Ei"],
-          ["Tasearvo", item.vuokrakulut[latestYear]?.tasearvo ?? "Ei saatavilla"],
-          ["Ylläpitokulut / v", yllapitoYhteensa ?? "Ei saatavilla"],
-          ["Vuokratulot / v", vuokratulot ?? "Ei saatavilla"],
-          ["Käyttöaste (%)", kayttoaste ?? "Ei tietoa"],
-        ]}
-      />
+    return (
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}>
+        <DetailCard
+          title="Kiinteistön tiedot"
+          rows={[
+            ["Pinta-ala", item.pinta_ala ?? "Ei tietoa"],
+            ["Rakennusvuosi", item.rakennusvuosi ?? "Ei tietoa"],
+            ["Käyttötarkoitus", item.kayttotarkoitus ?? "Ei tietoa"],
+            ["Suojelukohde", item.suojelukohde ? "Kyllä" : "Ei"],
+            ["Tasearvo", item.vuokrakulut[latestYear]?.tasearvo ?? "Ei saatavilla"],
+            ["Ylläpitokulut / v", yllapitoYhteensa ?? "Ei saatavilla"],
+            ["Vuokratulot / v", vuokratulot ?? "Ei saatavilla"],
+            ["Käyttöaste (%)", kayttoaste ?? "Ei tietoa"],
+          ]}
+        />
 
-      <DetailCard
-        title="Salkutus"
-        rows={[
-          [
-            "Salkku",
-            <span style={badgeStyle(item.oma_salkku)}>{item.oma_salkku}</span>,
-          ],
-          ["Pisteet", item.painotetutPisteet.toFixed(1)],
-          ["A > 225  •  B > 175  •  C > 125  •  D < 125", ""],
-          [
-            "Toimenpiteet",
-            item.toimenpiteet?.length > 0
-              ? item.toimenpiteet.map((t) => t.otsikko).join(", ")
-              : "Ei kirjattuja toimenpiteitä",
-          ],
-        ]}
-      />
-    </div>
-  );
+        <DetailCard
+          title="Salkutus"
+          rows={[
+            [
+              "Salkku",
+              <span style={badgeStyle(item.oma_salkku)}>{item.oma_salkku}</span>,
+            ],
+            ["Pisteet", item.painotetutPisteet.toFixed(1)],
+            ["A > 225  •  B > 175  •  C > 125  •  D < 125", ""],
+            [
+              "Toimenpiteet",
+              item.toimenpiteet?.length > 0
+                ? item.toimenpiteet.map((t) => t.otsikko).join(", ")
+                : "Ei kirjattuja toimenpiteitä",
+            ],
+          ]}
+        />
+      </div>
+    );
+  }
+  catch (error) {
+    console.error("Error in PerustiedotTab:", error);
+    return <div>Virhe tietojen lataamisessa</div>;
+  }
 }

--- a/src/components/tabs/PerustiedotTab.tsx
+++ b/src/components/tabs/PerustiedotTab.tsx
@@ -10,50 +10,96 @@ interface Props {
 }
 
 export default function PerustiedotTab({ item, latestYear }: Props) {
-  try {
-    const { yllapitoYhteensa, vuokratulot, kayttoaste } = computeFinancials(
-      item,
-      latestYear,
-    );
+  const { yllapitoYhteensa, vuokratulot, kayttoaste } = computeFinancials(
+    item,
+    latestYear,
+  );
 
-    return (
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}>
-        <DetailCard
-          title="Kiinteistön tiedot"
-          rows={[
-            ["Pinta-ala", item.pinta_ala ?? "Ei tietoa"],
-            ["Rakennusvuosi", item.rakennusvuosi ?? "Ei tietoa"],
-            ["Käyttötarkoitus", item.kayttotarkoitus ?? "Ei tietoa"],
-            ["Suojelukohde", item.suojelukohde ? "Kyllä" : "Ei"],
-            ["Tasearvo", item.vuokrakulut[latestYear]?.tasearvo ?? "Ei saatavilla"],
-            ["Ylläpitokulut / v", yllapitoYhteensa ?? "Ei saatavilla"],
-            ["Vuokratulot / v", vuokratulot ?? "Ei saatavilla"],
-            ["Käyttöaste (%)", kayttoaste ?? "Ei tietoa"],
-          ]}
-        />
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px", overflow: "visible" }}>
+      <DetailCard
+        title="Kiinteistön tiedot"
+        rows={[
+          ["Pinta-ala", item.pinta_ala ?? "Ei tietoa"],
+          ["Rakennusvuosi", item.rakennusvuosi ?? "Ei tietoa"],
+          ["Käyttötarkoitus", item.kayttotarkoitus ?? "Ei tietoa"],
+          ["Suojelukohde", item.suojelukohde ? "Kyllä" : "Ei"],
 
-        <DetailCard
-          title="Salkutus"
-          rows={[
-            [
-              "Salkku",
-              <span style={badgeStyle(item.oma_salkku)}>{item.oma_salkku}</span>,
-            ],
-            ["Pisteet", item.painotetutPisteet.toFixed(1)],
-            ["A > 225  •  B > 175  •  C > 125  •  D < 125", ""],
-            [
-              "Toimenpiteet",
-              item.toimenpiteet?.length > 0
-                ? item.toimenpiteet.map((t) => t.otsikko).join(", ")
-                : "Ei kirjattuja toimenpiteitä",
-            ],
-          ]}
-        />
-      </div>
-    );
-  }
-  catch (error) {
-    console.error("Error in PerustiedotTab:", error);
-    return <div>Virhe tietojen lataamisessa</div>;
-  }
+          [
+            "Tasearvo",
+            <Tooltip
+              label={
+                `Tasearvo (${latestYear})\n` +
+                `= vuokrakulut[${latestYear}].tasearvo\n` +
+                `(jos puuttuu → 0)`
+              }
+            >
+              <span>
+                {(item.vuokrakulut?.[latestYear]?.tasearvo ?? 0).toLocaleString("fi-FI")} €
+              </span>
+            </Tooltip>,
+          ],
+
+          [
+            "Ylläpitokulut / v",
+            <Tooltip
+              label={
+                `Ylläpitokulut (${latestYear})\n` +
+                `= Σ yllapitokulut[${latestYear}][kululaji]\n` +
+                `esim. sahko + lammitys + vesi + huolto + ...`
+              }
+            >
+              <span>{(yllapitoYhteensa ?? 0).toLocaleString("fi-FI")} €</span>
+            </Tooltip>,
+          ],
+
+          [
+            "Vuokratulot / v",
+            <Tooltip
+              label={
+                `Vuokratulot / v (${latestYear})\n` +
+                `= vuokrausaste_m2 * neliövuokra * 12\n` +
+                `(jos puuttuu → 0)`
+              }
+            >
+              <span>{(vuokratulot ?? 0).toLocaleString("fi-FI")} €</span>
+            </Tooltip>,
+          ],
+
+          [
+            "Käyttöaste (%)",
+            <Tooltip
+              label={
+                `Käyttöaste (%) (${latestYear})\n` +
+                `= (vuokrausaste_m2 / pinta_ala) * 100\n` +
+                `pyöristetään kokonaisluvuksi`
+              }
+            >
+              <span>{(kayttoaste ?? 0).toLocaleString("fi-FI")} %</span>
+            </Tooltip>,
+          ],
+        ]}
+      />
+
+      <DetailCard
+        title="Salkutus"
+        rows={[
+          [
+            "Salkku",
+            <span style={badgeStyle(item.oma_salkku)}>
+              {item.oma_salkku}
+            </span>,
+          ],
+          ["Pisteet", item.painotetutPisteet.toFixed(1)],
+          ["A > 225  •  B > 175  •  C > 125  •  D < 125", ""],
+          [
+            "Toimenpiteet",
+            item.toimenpiteet?.length > 0
+              ? item.toimenpiteet.map((t) => t.otsikko).join(", ")
+              : "Ei kirjattuja toimenpiteitä",
+          ],
+        ]}
+      />
+    </div>
+  );
 }

--- a/src/components/tabs/TalousTab.tsx
+++ b/src/components/tabs/TalousTab.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 function fmt(value: number) {
-  return `${Math.round(value).toLocaleString("fi-FI")} €`;
+  return `${value.toLocaleString("fi-FI", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €`;
 }
 
 function fmtDec(value: number, decimals = 2) {
@@ -74,8 +74,8 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
   const vuokra = item.vuokrakulut?.[selectedYear];
 
   const neliövuokra =
-    vuokra?.vuokrattu && vuokra.vuokrattu > 0
-      ? vuokra.kokonaisvuokra / vuokra.vuokrattu / 12
+    vuokra?.vuokrattavissa && vuokra.vuokrattavissa > 0
+      ? vuokra.kokonaisvuokra / vuokra.vuokrattavissa
       : 0;
 
   const kuukausitulo = Math.round(vuokratulot / 12);
@@ -128,42 +128,64 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
   );
 
   return (
-    <div
-      style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}
-    >
-      {/* ── MAINTENANCE EXPENSES ─────────────────────────────────── */}
-      <div style={cardStyle}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: 12,
-          }}
-        >
-          <h3 style={sectionTitle}>Ylläpitokulut</h3>
-          <button onClick={() => setShowYllapitoModal(true)}>✎ Muokkaa</button>
-        </div>
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+      {/* ── YEAR FILTER ───────────────────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          gap: 6,
+          flexWrap: "wrap",
+          paddingBottom: 12,
+          borderBottom: `1px solid ${theme.colors.border}`,
+          marginBottom: 4,
+        }}
+      >
+        {years.map(({ year }) => (
+          <button
+            key={year}
+            onClick={() => setSelectedYear(year)}
+            style={yearBtn(year)}
+          >
+            {year}
+          </button>
+        ))}
+      </div>
 
-        {/* Year pills */}
-        <div
-          style={{
-            display: "flex",
-            gap: 6,
-            flexWrap: "wrap",
-            marginBottom: 12,
-          }}
-        >
-          {years.map(({ year }) => (
-            <button
-              key={year}
-              onClick={() => setSelectedYear(year)}
-              style={yearBtn(year)}
-            >
-              {year}
-            </button>
-          ))}
-        </div>
+      {/* ── VIEW MODE FILTER ──────────────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          gap: 6,
+          flexWrap: "wrap",
+          paddingBottom: 12,
+          borderBottom: `1px solid ${theme.colors.border}`,
+        }}
+      >
+        <button style={viewBtn("year")} onClick={() => setViewMode("year")}>
+          Vuosi
+        </button>
+        <button style={viewBtn("month")} onClick={() => setViewMode("month")}>
+          Kuukausi
+        </button>
+      </div>
+
+      {/* ── CONTENT CARDS ─────────────────────────────────────────── */}
+      <div
+        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "20px" }}
+      >
+        {/* ── MAINTENANCE EXPENSES ─────────────────────────────────── */}
+        <div style={cardStyle}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 12,
+            }}
+          >
+            <h3 style={sectionTitle}>Ylläpitokulut</h3>
+            <button onClick={() => setShowYllapitoModal(true)}>✎ Muokkaa</button>
+          </div>
 
         {!yllapito ? (
           <p style={{ color: theme.colors.textMuted }}>
@@ -221,15 +243,6 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
         >
           <h3 style={sectionTitle}>Vuokraustiedot</h3>
           <div style={{ display: "flex", gap: 6 }}>
-            <button style={viewBtn("year")} onClick={() => setViewMode("year")}>
-              Vuosi
-            </button>
-            <button
-              style={viewBtn("month")}
-              onClick={() => setViewMode("month")}
-            >
-              Kuukausi
-            </button>
             <button onClick={() => setEditingVuokraYear(selectedYear)}>
               ✎ Muokkaa
             </button>
@@ -249,31 +262,6 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
             </button>
           </div>
         </div>
-
-        {/* Year pills */}
-        <div
-          style={{
-            display: "flex",
-            gap: 6,
-            flexWrap: "wrap",
-            marginBottom: 12,
-          }}
-        >
-          {years.map(({ year }) => (
-            <button
-              key={year}
-              onClick={() => setSelectedYear(year)}
-              style={yearBtn(year)}
-            >
-              {year}
-            </button>
-          ))}
-        </div>
-
-        {/* Edit / delete for selected year */}
-        {vuokra && (
-          <div style={{ display: "flex", gap: 6, marginBottom: 12 }}></div>
-        )}
 
         {vuokra ? (
           <>
@@ -353,6 +341,7 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
             Ei vuokratietoja vuodelle {selectedYear}.
           </p>
         )}
+      </div>
       </div>
 
       {/* ── MODALS ───────────────────────────────────────────────── */}

--- a/src/components/tabs/TalousTab.tsx
+++ b/src/components/tabs/TalousTab.tsx
@@ -33,14 +33,24 @@ function calcYllapitoTotal(
   return Math.round(fixed + extra);
 }
 
+function yearsIndex(item: Kiinteisto) {
+  return [
+    ...new Set([
+      ...Object.keys(item.yllapitokulut ?? {}),
+      ...Object.keys(item.vuokrakulut ?? {}),
+    ]),
+  ]
+    .map(Number)
+    .sort((a, b) => b - a)
+    .map((year) => ({
+      year,
+      yllapito: item.yllapitokulut?.[year] ?? null,
+      vuokra: item.vuokrakulut?.[year] ?? null,
+    }));
+}
+
 export default function TalousTab({ item, latestYear, onUpdate }: Props) {
-  // Shared year selection — both panels follow the same selected year
-  const allYllapitoYears = Object.keys(item.yllapitokulut ?? {})
-    .map(Number)
-    .sort((a, b) => b - a);
-  const allVuokraYears = Object.keys(item.vuokrakulut ?? {})
-    .map(Number)
-    .sort((a, b) => b - a);
+  const years = yearsIndex(item);
 
   const [selectedYear, setSelectedYear] = useState<number>(latestYear);
   const [viewMode, setViewMode] = useState<"year" | "month">("year");
@@ -144,13 +154,13 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
             marginBottom: 12,
           }}
         >
-          {allYllapitoYears.map((y) => (
+          {years.map(({ year }) => (
             <button
-              key={y}
-              onClick={() => setSelectedYear(y)}
-              style={yearBtn(y)}
+              key={year}
+              onClick={() => setSelectedYear(year)}
+              style={yearBtn(year)}
             >
-              {y}
+              {year}
             </button>
           ))}
         </div>
@@ -249,13 +259,13 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
             marginBottom: 12,
           }}
         >
-          {allVuokraYears.map((y) => (
+          {years.map(({ year }) => (
             <button
-              key={y}
-              onClick={() => setSelectedYear(y)}
-              style={yearBtn(y)}
+              key={year}
+              onClick={() => setSelectedYear(year)}
+              style={yearBtn(year)}
             >
-              {y}
+              {year}
             </button>
           ))}
         </div>
@@ -362,7 +372,7 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
       {showVuokraAddModal && (
         <VuokrakulutModal
           mode="add"
-          existingYears={allVuokraYears}
+          existingYears={years.map((y) => y.year)}
           onSave={(year, data) =>
             onUpdate({
               ...item,
@@ -376,7 +386,7 @@ export default function TalousTab({ item, latestYear, onUpdate }: Props) {
       {editingVuokraYear != null && (
         <VuokrakulutModal
           mode="edit"
-          existingYears={allVuokraYears}
+          existingYears={years.map((y) => y.year)}
           initial={{
             year: editingVuokraYear,
             data: item.vuokrakulut[editingVuokraYear],

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ export type VuokraKulut = {
     // Perustiedot
     tasearvo: number;
     vuokrausaste_m2: number;
-    neliövuokra: number; // calculated as = kokonaisvuokra / vuokrattavissa / 12
     kokonaisvuokra: number; 
 
     // Kulutus

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,8 @@ export type VuokraKulut = {
     // Perustiedot
     tasearvo: number;
     vuokrausaste_m2: number;
-    neliövuokra: number;
+    neliövuokra: number; // calculated as = kokonaisvuokra / vuokrattavissa / 12
+    kokonaisvuokra: number; 
 
     // Kulutus
     sahkonkulutus: number;
@@ -24,11 +25,9 @@ export type VuokraKulut = {
     yllapitoKorjaukset: number;
     maavuokra: number;
     vakuutus: number;
-
-    // Vuokratulot — m² values, income derived from these
+    
     vuokrattu: number;       // rented m²
     vuokrattavissa: number;  // available m²
-    // kokonaisvuokra is NOT stored — always derived as vuokrattu * neliövuokra * 12
 };
 
 type Pisteet = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type VuokraKulut = {
     tasearvo: number;
     vuokrausaste_m2: number;
     kokonaisvuokra: number; 
+    neliovuokra: number;
 
     // Kulutus
     sahkonkulutus: number;

--- a/src/utils/kiinteistoUtils.ts
+++ b/src/utils/kiinteistoUtils.ts
@@ -56,7 +56,7 @@ export function toimenpiteetByYear(item: Kiinteisto): Record<number, number> {
 export interface Financials {
   yllapitoYhteensa: number;     // maintenance expenses
   toimenpiteetYhteensa: number; // actions cost for the year (auto from toimenpiteet)
-  vuokratulot: number;          // vuokrattu m² × neliövuokra × 12
+  vuokratulot: number;          // kokonaisvuokra (vuosittain)
   kayttoaste: number;           // vuokrattu / vuokrattavissa %
   kulutYhteensa: number;        // yllapito + toimenpiteet + korjaukset + maavuokra + vakuutus
   tulos: number;                // vuokratulot − kulutYhteensa
@@ -70,11 +70,11 @@ export function computeFinancials(item: Kiinteisto, year: number): Financials {
 
   const toimenpiteetYhteensa = Math.round(toimenpiteetByYear(item)[year] ?? 0);
 
-  // Income: rented m² × price per m² × 12 months
-  const vuokrattu = vuokra?.vuokrattu ?? vuokra?.vuokrausaste_m2 ?? 0; // fallback for legacy data
-  const vuokratulot = vuokra?.neliövuokra
-    ? Math.round(vuokrattu * vuokra.neliövuokra * 12)
-    : 0;
+  // Income: use kokonaisvuokra directly (already annual)
+  const vuokratulot = Math.round(vuokra?.kokonaisvuokra ?? 0);
+
+  // Rented m²
+  const vuokrattu = vuokra?.vuokrattu ?? vuokra?.vuokrausaste_m2 ?? 0;
 
   // Occupancy: rented / available
   const vuokrattavissa = vuokra?.vuokrattavissa ?? item.pinta_ala;


### PR DESCRIPTION
Refactor financial calculations and rental income display

- Move year and view mode filters to top level (above cards)
- Remove duplicate year filter pills from maintenance and rental cards
- Change rental income calculation to use kokonaisvuokra directly
- Remove neliövuokra from stored fields (now calculated: kokonaisvuokra / vuokrattavissa)
- Update fmt() to display currency with 2 decimal places (euros)
- Fix: Add missing vuokrattu variable in computeFinancials
- Remove neliövuokra field from VuokraKulut type definition
- Simplify financial calculations and improve data consistency